### PR TITLE
Apply all config options recognized by PurgeCSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,15 +34,18 @@ class PurgecssPlugin {
   // Examples: UglifyJS, CSSMin.
   // optimize(file) { return Promise.resolve({data: minify(file.data)}); }
   optimize(file) {
-    let purger = new Purgecss({
-      content: this.config.paths,
-      extractors: this.config.extractors,
-      css: [file.data],
-      stdin: true
-    });
+    let purger = new Purgecss(
+      Object.assign(this.config, {
+        content: this.config.paths,
+        css: [file.data],
+        stdin: true
+      })
+    );
 
     let purgeResult = purger.purge();
-    return Promise.resolve({data: purgeResult[0].css});
+    return Promise.resolve({
+      data: purgeResult[0].css
+    });
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -67,5 +67,6 @@ PurgecssPlugin.prototype.pattern = /\.css$/;
 // The default value is '*' for usual plugins and
 // 'production' for optimizers.
 // PurgecssPlugin.prototype.defaultEnv = 'production';
+PurgecssPlugin.prototype.defaultEnv = '*';
 
 module.exports = PurgecssPlugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purgecss-brunch",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Adds purgecss support to brunch.",
   "author": "Jeffrey Guenther (guenther.jeffrey@gmail.com)",
   "homepage": "https://github.com/jeffreyguenther/purgecss-brunch.git",


### PR DESCRIPTION
I submit 2 minor modifications:

1) Forward all configuration options to PurgeCSS. This is especially usefull for whitelisting of classes. I am doing a Phoenix application and some classnames appear only in JS code. Even being able to scan JS files, there is no clear method to recognise class names, as opposed to HTML er EEX files. So whitelisting is a good compromise.

2) Enable the plugin even in development. It is pretty fast, not slowing down the development cycle. And it is useful to catch any missing whitlisting in development, and not only after a production build.
